### PR TITLE
fix dgraph adapter createUser

### DIFF
--- a/packages/adapter-dgraph/src/index.ts
+++ b/packages/adapter-dgraph/src/index.ts
@@ -50,6 +50,7 @@ export function DgraphAdapter(
   const fragments = { ...defaultFragments, ...options?.fragments }
   return {
     async createUser(input) {
+      if (input?.id) { delete (input.id) } // Dgraph will generate the ID by itself
       const result = await c.run<{ user: any[] }>(
         /* GraphQL */ `
           mutation ($input: [AddUserInput!]!) {


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

**NOTE**:

- It's a good idea to open an issue first to discuss potential changes.
- Please make sure that you are _NOT_ opening a PR to fix a potential security vulnerability. Instead, please follow the [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md) to disclose the issue to us confidentially.

-->

## ☕️ Reasoning

<!-- What changes are being made? What feature/bug is being fixed here? -->
Dgraph will generate the ID by itself. In Dgraph, every node has a unique 64-bit identifier that you can expose in GraphQL using the ID type. An ID is auto-generated, immutable and never reused. Each type can have at most one ID field.

The ID type works great when you need to use an identifier on nodes and don’t need to set that identifier externally 
[DGraph type docs ](https://dgraph.io/docs/graphql/schema/types/)

Since next-auth.js or auth.js creates a new user id, this causes an error and does not save the entry to dgraph

## 🧢 Checklist

- [X] Documentation
- [X] Tests
- [X] Ready to be merged

## 🎫 Affected issues

<!--
Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR. And include text like the following to close them automatically when this is merged:

Fixes: INSERT_ISSUE_LINK_HERE
-->

## 📌 Resources

- [Security guidelines](https://github.com/nextauthjs/.github/blob/main/SECURITY.md)
- [Contributing guidelines](https://github.com/nextauthjs/.github/blob/main/CONTRIBUTING.md)
- [Code of conduct](https://github.com/nextauthjs/.github/blob/main/CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
